### PR TITLE
Add better portability to uvloop and winloop

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ winuvloop.install()
 
 ## Requirements
 
-- Python 3.11 or higher
+- Python 3.8 or higher
 - `uvloop` for POSIX systems
 - `winloop` for Windows systems
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # winuvloop
 
 `winuvloop` is a Python package that ensures you always use the best event loop for your platform. 
-It automatically sets up `uvloop` on Linux/POSIX systems and `winloop` on Windows, optimizing performance and compatibility without extra configuration. 
+It automatically sets up [uvloop](https://github.com/MagicStack/uvloop) on Linux/POSIX systems and [winloop](https://github.com/Vizonex/winloop) on Windows, optimizing performance and compatibility without extra configuration. 
 By using `winuvloop`, you can streamline your development process and focus on writing your application code, knowing that the right event loop is always in place for seamless cross-platform functionality.
 
 ## Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "^3.8"
 uvloop = {version = "*", markers = "sys_platform != 'win32'"}
 winloop = {version = "*", markers = "sys_platform == 'win32'"}
 

--- a/winuvloop/__init__.py
+++ b/winuvloop/__init__.py
@@ -1,12 +1,74 @@
+import asyncio as __asyncio
 import sys
+import typing as _typing
+from asyncio.events import BaseDefaultEventLoopPolicy as __BasePolicy
 
-if sys.platform in ('win32', 'cygwin', 'cli'):
-    import winloop
-    run = winloop.run
-    install = winloop.install
+_T = _typing.TypeVar("_T")
+
+
+if not _typing.TYPE_CHECKING:
+
+    if sys.platform in ("win32", "cygwin", "cli"):
+        import winloop
+
+        EventLoopPolicy = winloop.EventLoopPolicy
+        new_event_loop = winloop.new_event_loop
+        Loop = winloop.Loop
+        run = winloop.run
+        install = winloop.install
+    else:
+        import uvloop
+
+        EventLoopPolicy = uvloop.EventLoopPolicy
+        new_event_loop = uvloop.new_event_loop
+        Loop = uvloop.Loop
+        run = uvloop.run
+        install = uvloop.install
+
 else:
-    import uvloop
-    run = uvloop.run
-    install = uvloop.install
 
-__all__ = [run, install]
+    class Loop(__asyncio.BaseEventLoop):  # type: ignore
+        pass
+
+    def new_event_loop() -> Loop:
+        """Return a new event loop."""
+        return Loop()
+
+    def install() -> None:
+        """A helper function to install uvloop/winloop policy."""
+
+    def run(
+        main: _typing.Coroutine[_typing.Any, _typing.Any, _T],
+        *,
+        loop_factory: _typing.Optional[_typing.Callable[[], Loop]] = new_event_loop,
+        debug: _typing.Optional[bool] = None,
+    ) -> _T:
+        """The preferred way of running a coroutine with winuvloop."""
+
+    class EventLoopPolicy(__BasePolicy):
+        """Event loop policy.
+
+        The preferred way to make your application use winuvloop:
+
+        >>> import asyncio
+        >>> import winuvloop
+        >>> asyncio.set_event_loop_policy(winuvloop.EventLoopPolicy())
+        >>> asyncio.get_event_loop()
+
+        """
+
+        def _loop_factory(self) -> Loop:
+            return new_event_loop()
+
+        if _typing.TYPE_CHECKING:
+            # EventLoopPolicy doesn't implement these, but since they are marked
+            # as abstract in typeshed, we have to put them in so mypy thinks
+            # the base methods are overridden. This is the same approach taken
+            # for the Windows event loop policy classes in typeshed.
+            def get_child_watcher(self) -> _typing.NoReturn: ...
+
+            def set_child_watcher(self, watcher: _typing.Any) -> _typing.NoReturn: ...
+
+
+__all__ = ["run", "install", "EventLoopPolicy", "Loop", "new_event_loop"]
+

--- a/winuvloop/__init__.py
+++ b/winuvloop/__init__.py
@@ -1,12 +1,12 @@
-import asyncio as __asyncio
+import asyncio
 import sys
-import typing as _typing
-from asyncio.events import BaseDefaultEventLoopPolicy as __BasePolicy
+import typing
+from asyncio.events import BaseDefaultEventLoopPolicy 
 
-_T = _typing.TypeVar("_T")
+_T = typing.TypeVar("_T")
 
 
-if not _typing.TYPE_CHECKING:
+if not typing.TYPE_CHECKING:
 
     if sys.platform in ("win32", "cygwin", "cli"):
         import winloop
@@ -27,7 +27,7 @@ if not _typing.TYPE_CHECKING:
 
 else:
 
-    class Loop(__asyncio.BaseEventLoop):  # type: ignore
+    class Loop(asyncio.BaseEventLoop):  # type: ignore
         pass
 
     def new_event_loop() -> Loop:
@@ -45,7 +45,7 @@ else:
     ) -> _T:
         """The preferred way of running a coroutine with winuvloop."""
 
-    class EventLoopPolicy(__BasePolicy):
+    class EventLoopPolicy(BaseDefaultEventLoopPolicy):
         """Event loop policy.
 
         The preferred way to make your application use winuvloop:
@@ -64,9 +64,9 @@ else:
             # as abstract in typeshed, we have to put them in so mypy thinks
             # the base methods are overridden. This is the same approach taken
             # for the Windows event loop policy classes in typeshed.
-            def get_child_watcher(self) -> _typing.NoReturn: ...
+            def get_child_watcher(self) -> typing.NoReturn: ...
 
-            def set_child_watcher(self, watcher: _typing.Any) -> _typing.NoReturn: ...
+            def set_child_watcher(self, watcher: _typing.Any) -> typing.NoReturn: ...
 
 
 __all__ = ["run", "install", "EventLoopPolicy", "Loop", "new_event_loop"]

--- a/winuvloop/__init__.py
+++ b/winuvloop/__init__.py
@@ -32,7 +32,7 @@ else:
 
     def new_event_loop() -> Loop:
         """Return a new event loop."""
-        return Loop()
+        ...
 
     def install() -> None:
         """A helper function to install uvloop/winloop policy."""
@@ -57,8 +57,7 @@ else:
 
         """
 
-        def _loop_factory(self) -> Loop:
-            return new_event_loop()
+        def _loop_factory(self) -> Loop:...
 
         if _typing.TYPE_CHECKING:
             # EventLoopPolicy doesn't implement these, but since they are marked


### PR DESCRIPTION
Your project is a great idea so I decided to improve it. The added functions will be useful for modules like [aiomultiprocess](https://github.com/omnilib/aiomultiprocess) and [aiothreading](https://github.com/Vizonex/aiothreading) on top of that which require functions such as `new_event_loop` when you want to utilize any certain `ThreadPool` or `Pool` I also added the option of importing the `EventLoopPolicy` for when `install()` is deprecated on newer python versions after 3.12. Also I am working on making it so your library supports 3.8 and above.
