### PR TITLE
Fix uv Dependabot updates for Python 3.8 support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,11 +15,17 @@ updates:
           - "winloop"
       python-dev-tools:
         patterns:
-          - "build"
           - "pytest"
           - "ruff"
-          - "twine"
           - "uv-build"
+    ignore:
+      # Keep Python 3.8-compatible dev tool pins until runtime support drops 3.8.
+      - dependency-name: "build"
+        versions:
+          - ">=1.3"
+      - dependency-name: "twine"
+        versions:
+          - ">=6"
     commit-message:
       prefix: "deps"
       include: "scope"


### PR DESCRIPTION
## Summary

- keep build and twine out of the uv Dependabot dev-tool group while Python 3.8 remains supported
- ignore build >=1.3 and twine >=6 because those ranges do not resolve for the Python 3.8 split
- preserve updates for pytest, ruff, uv-build, uvloop, and winloop

## Validation

- uv lock --check
- uv run ruff check .
- parsed .github/dependabot.yml with PyYAML