### PR TITLE
Add auto-merge and automatic releases

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,106 @@
+name: Auto Release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: write
+
+concurrency:
+  group: auto-release
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    name: Tag new project version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Read project version
+        id: version
+        run: |
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import re
+          import tomllib
+
+          with open("pyproject.toml", "rb") as file:
+              version = tomllib.load(file)["project"]["version"]
+
+          if not re.fullmatch(r"\d+\.\d+\.\d+(?:[a-zA-Z0-9.+-]+)?", version):
+              raise SystemExit(f"Unsupported release version: {version}")
+
+          print(f"version={version}")
+          print(f"tag=v{version}")
+          PY
+
+      - name: Check whether tag already exists
+        id: tag
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure version moves forward
+        if: steps.tag.outputs.exists == 'false'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          latest_tag="$(git tag -l 'v[0-9]*' --sort=-v:refname | head -n 1)"
+
+          if [ -z "${latest_tag}" ]; then
+            exit 0
+          fi
+
+          LATEST_TAG="${latest_tag}" python - <<'PY'
+          import os
+          import re
+
+          def parse(version: str) -> tuple[int, int, int]:
+              match = re.fullmatch(r"v?(\d+)\.(\d+)\.(\d+)(?:[a-zA-Z0-9.+-]+)?", version)
+              if not match:
+                  raise SystemExit(f"Unsupported version tag: {version}")
+              return tuple(int(part) for part in match.groups())
+
+          current = parse(os.environ["VERSION"])
+          latest = parse(os.environ["LATEST_TAG"])
+
+          if current <= latest:
+              raise SystemExit(
+                  f"Refusing to tag v{os.environ['VERSION']}: latest tag is "
+                  f"{os.environ['LATEST_TAG']}"
+              )
+          PY
+
+      - name: Create and push release tag
+        if: steps.tag.outputs.exists == 'false'
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${TAG}" -m "Release ${TAG}"
+          git push origin "${TAG}"
+
+      - name: Dispatch release workflow
+        if: steps.tag.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: gh workflow run release.yml --ref "${TAG}"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,56 @@
+name: Dependabot Auto-Merge
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    name: Auto-merge Dependabot PR
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge Dependabot pull requests after CI passes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_PULL_REQUESTS: ${{ toJson(github.event.workflow_run.pull_requests) }}
+        run: |
+          PR_NUMBERS="$(python - <<'PY'
+          import json
+          import os
+
+          pull_requests = json.loads(os.environ["RUN_PULL_REQUESTS"])
+          numbers = [str(pr["number"]) for pr in pull_requests]
+          print(" ".join(numbers))
+          PY
+          )"
+
+          if [ -z "${PR_NUMBERS}" ]; then
+            echo "No pull requests are associated with this CI run."
+            exit 0
+          fi
+
+          for number in ${PR_NUMBERS}; do
+            author="$(gh pr view "${number}" --json author --jq '.author.login')"
+            state="$(gh pr view "${number}" --json state --jq '.state')"
+            draft="$(gh pr view "${number}" --json isDraft --jq '.isDraft')"
+
+            if [ "${author}" != "app/dependabot" ] && [ "${author}" != "dependabot[bot]" ]; then
+              echo "Skipping #${number}: author is ${author}."
+              continue
+            fi
+
+            if [ "${state}" != "OPEN" ] || [ "${draft}" != "false" ]; then
+              echo "Skipping #${number}: state=${state}, draft=${draft}."
+              continue
+            fi
+
+            gh pr merge "${number}" --squash --delete-branch \
+              --subject "$(gh pr view "${number}" --json title --jq '.title')" \
+              --body "Automatically merged after CI passed."
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - "v*.*.*"
@@ -51,7 +52,7 @@ jobs:
       name: pypi
       url: https://pypi.org/project/winuvloop/
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - name: Download distributions
@@ -65,3 +66,12 @@ jobs:
 
       - name: Publish distributions
         run: uv publish --trusted-publishing always dist/*
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" dist/* \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "${GITHUB_REF_NAME}" \
+            --generate-notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,14 @@ All notable changes to `winuvloop` are documented here.
 - Add `backend_name()`, `backend()`, and `__backend__` for support visibility.
 - Add a typed package marker.
 - Add pytest coverage for platform selection, exports, and backend delegation.
+- Add real backend smoke tests for CI compatibility coverage.
 - Add ruff linting.
 - Replace the release workflow with a tag-based trusted publishing flow.
+- Add automatic release tagging from `pyproject.toml` versions on `main`.
+- Add GitHub Release creation with release artifacts.
 - Add a CI workflow for lockfile checks, linting, tests, build validation, and
   package metadata checks.
+- Add Dependabot auto-merge after CI passes.
 - Update Dependabot to track `uv` dependencies and GitHub Actions.
 
 ## 0.2.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,11 @@ uv run twine check dist/*
 - Minor releases add public API or support for new Python/backend versions.
 - Major releases remove compatibility or change public behavior.
 
+Releases are automatic after a version change lands on `main`. If
+`pyproject.toml` contains a version without a matching `vX.Y.Z` tag, GitHub
+Actions creates the tag and dispatches `release.yml`. The release workflow
+builds, validates, publishes to PyPI, and creates a GitHub Release.
+
 ## Dependency Policy
 
 Runtime dependencies should stay aligned with supported `uvloop` and `winloop`
@@ -36,6 +41,7 @@ releases. Avoid upper bounds unless a known incompatibility exists; upper bounds
 can block users from receiving fixed wheels and security releases.
 
 Development dependencies are locked with `uv.lock` and updated by Dependabot.
+Dependabot pull requests are merged automatically after CI passes.
 
 ## Pull Request Guidelines
 

--- a/README.md
+++ b/README.md
@@ -2,26 +2,33 @@
 
 [![PyPI](https://img.shields.io/pypi/v/winuvloop.svg)](https://pypi.org/project/winuvloop/)
 [![Python](https://img.shields.io/pypi/pyversions/winuvloop.svg)](https://pypi.org/project/winuvloop/)
+[![Downloads](https://img.shields.io/pypi/dm/winuvloop.svg)](https://pypi.org/project/winuvloop/)
 [![CI](https://github.com/aviadr1/winuvloop/actions/workflows/ci.yml/badge.svg)](https://github.com/aviadr1/winuvloop/actions/workflows/ci.yml)
 [![License](https://img.shields.io/pypi/l/winuvloop.svg)](https://github.com/aviadr1/winuvloop/blob/main/LICENSE)
 
-`winuvloop` is a small cross-platform asyncio helper that selects the fastest
-event loop for the operating system:
+`winuvloop` is a tiny cross-platform asyncio event loop selector:
 
-| Platform | Backend |
+| Platform | Backend used by `winuvloop` |
 | --- | --- |
 | Windows | [`winloop`](https://github.com/Vizonex/Winloop) |
 | Linux, macOS, POSIX | [`uvloop`](https://github.com/MagicStack/uvloop) |
 
-Use it when an application, library example, benchmark, or internal service
-should run with `uvloop` on Unix-like systems and `winloop` on Windows without
-duplicating platform checks in every entry point.
+It is useful when the same Python application, example, benchmark, CLI, or
+service should use a high-performance asyncio loop on both Windows and
+Unix-like systems without duplicating platform checks at every entry point.
 
-## Why
+## Why This Exists
 
-`uvloop` is the common high-performance event loop for asyncio applications on
-Linux and macOS. `winloop` brings a compatible API to Windows. `winuvloop`
-keeps the import and setup code the same across platforms:
+[`uvloop`](https://github.com/MagicStack/uvloop) is the established
+high-performance asyncio event loop for Linux, macOS, and other POSIX
+platforms. It is widely used for network-heavy asyncio workloads such as API
+servers, proxies, websocket services, crawlers, and async database clients.
+
+[`winloop`](https://github.com/Vizonex/Winloop) provides a uvloop-compatible
+API for Windows, where `uvloop` itself is not the Windows backend.
+
+`winuvloop` does not replace either upstream project. It gives you one import
+that chooses the right upstream backend:
 
 ```python
 import winuvloop
@@ -33,6 +40,24 @@ async def main() -> None:
 
 winuvloop.run(main())
 ```
+
+## When To Use It
+
+Use `winuvloop` when:
+
+- your project supports both Windows and Linux/macOS
+- examples or docs should stay platform-neutral
+- your CLI or application wants the fastest available asyncio loop by default
+- you want one dependency that resolves `uvloop` or `winloop` through platform
+  markers
+- you want to log or inspect which optimized backend was selected
+
+Use the upstream packages directly when:
+
+- your project only targets Linux/macOS: use `uvloop`
+- your project only targets Windows: use `winloop`
+- you need backend-specific APIs and do not want a selector layer
+- you are debugging an upstream event-loop issue and need to remove wrappers
 
 ## Installation
 
@@ -46,12 +71,12 @@ With `uv`:
 uv add winuvloop
 ```
 
-`winuvloop` declares platform-specific dependencies, so installers only resolve
+`winuvloop` declares platform-specific dependencies. Installers resolve only
 the backend needed for the current environment.
 
 ## Usage
 
-Prefer `run()` for new application entry points:
+Prefer `run()` for application entry points:
 
 ```python
 import winuvloop
@@ -77,7 +102,7 @@ winuvloop.install()
 asyncio.run(main())
 ```
 
-You can also inspect which backend was selected:
+You can inspect the selected backend for diagnostics and support logs:
 
 ```python
 import winuvloop
@@ -85,6 +110,7 @@ import winuvloop
 
 print(winuvloop.backend_name())  # "uvloop" or "winloop"
 print(winuvloop.__backend__)
+print(winuvloop.backend().__name__)
 ```
 
 The module re-exports the common backend API:
@@ -102,15 +128,31 @@ Backend-specific attributes are delegated to the selected upstream module.
 `winuvloop` targets CPython 3.8.1 and newer, matching the current published
 support range of `uvloop` and `winloop`.
 
-| Python | Status |
+| Environment | Status |
 | --- | --- |
-| 3.8-3.14 | Supported by current upstream wheels |
-| PyPy | Not supported by `uvloop` or `winloop` |
+| CPython 3.8-3.14 | Supported by current upstream wheels |
+| Linux/macOS | Uses `uvloop` |
+| Windows | Uses `winloop` |
+| PyPy | Not supported by the upstream native backends |
 | Windows ARM64 | Supported when `winloop` publishes a matching wheel |
 | Linux/macOS ARM64 | Supported when `uvloop` publishes a matching wheel |
 
 If an upstream backend does not publish a wheel for a specific interpreter or
 platform, installation may require local build tooling for that backend.
+
+## Testing Strategy
+
+CI runs on Linux, macOS, and Windows. It includes:
+
+- lockfile validation with `uv lock --check`
+- linting with `ruff`
+- wrapper unit tests that mock both backends
+- real backend smoke tests that call `winuvloop.run()` on the platform backend
+- source distribution and wheel builds
+- package metadata validation with `twine check`
+
+This keeps the wrapper behavior fast to test while still proving that the
+published backend dependencies are usable on each runner family.
 
 ## Development
 
@@ -119,20 +161,29 @@ locking, and builds.
 
 ```bash
 uv sync
-uv run pytest
 uv run ruff check .
+uv run pytest
 uv build
 uv run twine check dist/*
 ```
 
-The test suite mocks `uvloop` and `winloop` so wrapper behavior can be validated
-quickly without compiling native extensions on every platform.
+## Release And Automation
 
-## Release
+Dependabot updates are grouped for upstream event loops, Python tooling, and
+GitHub Actions. Dependabot PRs auto-merge after the CI workflow passes.
 
-Releases are built by GitHub Actions from `v*.*.*` tags and published to PyPI
-using trusted publishing. The PyPI project metadata links back to GitHub,
-issues, changelog, and the upstream backend projects for better discoverability.
+Releases are automatic:
+
+1. Change `project.version` in `pyproject.toml`.
+2. Merge to `main`.
+3. GitHub Actions creates the missing `vX.Y.Z` tag.
+4. GitHub Actions dispatches `release.yml` for that tag.
+5. The release workflow builds, validates, publishes to PyPI with trusted
+   publishing, and creates a GitHub Release.
+
+PyPI trusted publishing must be configured for the `release.yml` workflow and
+the `pypi` environment before the publish step can succeed. Manual tag pushes
+with the `vX.Y.Z` format still run the same release workflow.
 
 ## License
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+def import_real_winuvloop():
+    sys.modules.pop("winuvloop", None)
+    return importlib.import_module("winuvloop")
+
+
+async def answer() -> int:
+    return 42
+
+
+def test_real_backend_matches_platform() -> None:
+    winuvloop = import_real_winuvloop()
+    expected = "winloop" if sys.platform == "win32" else "uvloop"
+
+    assert winuvloop.backend_name() == expected
+    assert winuvloop.__backend__ == expected
+    assert winuvloop.backend().__name__ == expected
+
+
+def test_real_backend_runs_coroutine() -> None:
+    winuvloop = import_real_winuvloop()
+
+    assert winuvloop.run(answer()) == 42
+
+
+def test_real_backend_exposes_loop_factory() -> None:
+    winuvloop = import_real_winuvloop()
+    loop = winuvloop.new_event_loop()
+    try:
+        assert isinstance(loop, winuvloop.Loop)
+    finally:
+        loop.close()


### PR DESCRIPTION
## Summary

- add Dependabot auto-merge after the CI workflow succeeds
- add automatic version-tag creation from pyproject.toml on main and dispatch the release workflow for that tag
- keep tag-based/manual release support and create GitHub Releases with built artifacts
- add real backend smoke tests so CI validates uvloop on POSIX and winloop on Windows
- strengthen README and contributing docs around upstream vs winuvloop, compatibility, CI, Dependabot, and release automation

## Validation

- uv lock --check
- uv run ruff check .
- uv run pytest
- uv build
- uv run twine check dist/*
- parsed workflow and Dependabot YAML with PyYAML