### PR TITLE
Fix Dependabot auto-merge repository context

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Merge Dependabot pull requests after CI passes
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           RUN_PULL_REQUESTS: ${{ toJson(github.event.workflow_run.pull_requests) }}
         run: |
           PR_NUMBERS="$(python - <<'PY'


### PR DESCRIPTION
## Summary

- set GH_REPO for the Dependabot auto-merge workflow so gh commands work without a checked-out repository

## Validation

- parsed dependabot-automerge workflow YAML
- uv run ruff check .
- uv run pytest