### PR TITLE
Add PyPI token fallback for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,14 @@ jobs:
         uses: astral-sh/setup-uv@v8.1.0
 
       - name: Publish distributions
-        run: uv publish --trusted-publishing always dist/*
+        env:
+          PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          if [ -n "${PYPI_API_TOKEN}" ]; then
+            uv publish --token "${PYPI_API_TOKEN}" dist/*
+          else
+            uv publish --trusted-publishing always dist/*
+          fi
 
       - name: Create GitHub release
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,8 @@ uv run twine check dist/*
 Releases are automatic after a version change lands on `main`. If
 `pyproject.toml` contains a version without a matching `vX.Y.Z` tag, GitHub
 Actions creates the tag and dispatches `release.yml`. The release workflow
-builds, validates, publishes to PyPI, and creates a GitHub Release.
+builds, validates, publishes to PyPI through trusted publishing or the
+`PYPI_API_TOKEN` fallback secret, and creates a GitHub Release.
 
 ## Dependency Policy
 

--- a/README.md
+++ b/README.md
@@ -178,12 +178,13 @@ Releases are automatic:
 2. Merge to `main`.
 3. GitHub Actions creates the missing `vX.Y.Z` tag.
 4. GitHub Actions dispatches `release.yml` for that tag.
-5. The release workflow builds, validates, publishes to PyPI with trusted
-   publishing, and creates a GitHub Release.
+5. The release workflow builds, validates, publishes to PyPI, and creates a
+   GitHub Release.
 
 PyPI trusted publishing must be configured for the `release.yml` workflow and
-the `pypi` environment before the publish step can succeed. Manual tag pushes
-with the `vX.Y.Z` format still run the same release workflow.
+the `pypi` environment for credential-free publishing. If the repository still
+uses a `PYPI_API_TOKEN` secret, the release workflow can use that as a fallback.
+Manual tag pushes with the `vX.Y.Z` format still run the same release workflow.
 
 ## License
 


### PR DESCRIPTION
## Summary

- let release.yml use PYPI_API_TOKEN when present
- keep trusted publishing as the credential-free fallback when no token secret exists
- document the fallback release credential path

## Validation

- parsed release workflow YAML
- uv run ruff check .
- uv run pytest
- uv build
- uv run twine check dist/*