### PR TITLE
Add public API typing stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to `winuvloop` are documented here.
 
-## 0.2.1 - Unreleased
+## 0.2.2 - Unreleased
+
+- Add public API stubs for better editor and type-checker ergonomics.
+
+## 0.2.1 - 2026-04-25
 
 - Move packaging to standard PEP 621 metadata and the `uv_build` backend.
 - Replace `poetry.lock` with `uv.lock` for faster, reproducible development.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ The module re-exports the common backend API:
 
 Backend-specific attributes are delegated to the selected upstream module.
 
+## Typing
+
+`winuvloop` ships a `py.typed` marker and public API stubs for the selector
+module. The runtime values remain direct aliases to the selected upstream
+backend, so `winuvloop.Loop` is still `uvloop.Loop` on POSIX and `winloop.Loop`
+on Windows.
+
 ## Compatibility
 
 `winuvloop` targets CPython 3.8.1 and newer, matching the current published

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "winuvloop"
-version = "0.2.1"
+version = "0.2.2"
 description = "Cross-platform asyncio event loop selection: uvloop on POSIX and winloop on Windows."
 readme = "README.md"
 requires-python = ">=3.8.1"

--- a/src/winuvloop/__init__.pyi
+++ b/src/winuvloop/__init__.pyi
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import asyncio
+from types import ModuleType
+from typing import Any, Callable, Coroutine, TypeVar
+
+_T = TypeVar("_T")
+
+__backend__: str
+__version__: str
+
+
+class Loop(asyncio.AbstractEventLoop):
+    ...
+
+
+class EventLoopPolicy(asyncio.AbstractEventLoopPolicy):
+    ...
+
+
+def backend_name() -> str:
+    ...
+
+
+def backend() -> ModuleType:
+    ...
+
+
+def new_event_loop() -> Loop:
+    ...
+
+
+def install() -> None:
+    ...
+
+
+def run(
+    main: Coroutine[Any, Any, _T],
+    *,
+    loop_factory: Callable[[], Loop] | None = ...,
+    debug: bool | None = ...,
+    **run_kwargs: Any,
+) -> _T:
+    ...
+
+
+def __getattr__(name: str) -> Any:
+    ...

--- a/uv.lock
+++ b/uv.lock
@@ -1393,7 +1393,7 @@ wheels = [
 
 [[package]]
 name = "winuvloop"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "uvloop", marker = "platform_python_implementation == 'CPython' and sys_platform != 'win32'" },


### PR DESCRIPTION
## Summary

- extract the useful typing/API ergonomics idea from PR #1 into the modernized src-layout package
- add a public __init__.pyi stub while keeping runtime names as direct backend aliases
- document typing behavior and bump version to 0.2.2

## Why a .pyi stub instead of runtime Protocol/ABC wrappers

The runtime objects are intentionally direct aliases to uvloop or winloop objects. A .pyi stub improves editor and type-checker behavior without introducing wrapper classes that could alter identity checks or backend behavior.

## Validation

- uv lock --check
- uv run ruff check .
- uv run pytest
- uv build
- uv run twine check dist/*
- verified the wheel contains winuvloop/__init__.pyi and winuvloop/py.typed

Closes #1