### PR TITLE
[codex] Release 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 All notable changes to `winuvloop` are documented here.
 
-## 0.2.2 - Unreleased
+## 0.2.3 - 2026-04-25
 
-- Add public API stubs for better editor and type-checker ergonomics.
 - Add `backend_version()` for support logs and diagnostics.
 - Improve missing-backend import errors with Python implementation context.
 - Expand README guidance for `uvloop`, `winloop`, and `winuvloop` selection.
@@ -15,6 +14,10 @@ All notable changes to `winuvloop` are documented here.
 - Include tests and maintenance docs in the source distribution.
 - Keep Python 3.9 development installs on the compatible Twine line so
   Dependabot security updates can resolve.
+
+## 0.2.2 - 2026-04-25
+
+- Add public API stubs for better editor and type-checker ergonomics.
 
 ## 0.2.1 - 2026-04-25
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "winuvloop"
-version = "0.2.2"
+version = "0.2.3"
 description = "Use uvloop on Linux/macOS and winloop on Windows through one small asyncio compatibility import."
 readme = "README.md"
 requires-python = ">=3.8.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1397,7 +1397,7 @@ wheels = [
 
 [[package]]
 name = "winuvloop"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "uvloop", marker = "platform_python_implementation == 'CPython' and sys_platform != 'win32'" },


### PR DESCRIPTION
## Summary

- bump package version to `0.2.3`
- date the changelog entry for the completed compatibility, docs, CI, release, and Dependabot hardening work
- refresh `uv.lock` package metadata to `0.2.3`

## Validation

- `uv lock --check`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest`
- `uv run python -m compileall -q src tests`
- `uv run --python 3.8 python -m py_compile src/winuvloop/__init__.py`
- `uv build`
- `uv run twine check dist/*`
